### PR TITLE
Merge to master

### DIFF
--- a/check_for_clubhouse.sh
+++ b/check_for_clubhouse.sh
@@ -75,6 +75,11 @@ main() {
 		echo "If I said your PR body looked good, would you hold it against me?"
 		remove_clubhouse_labels
 		exit 0
+	elif [[ ${PR_BODY} =~ \(https:\/\/app\.clubhouse\.io\/shipt\/story\/[0-9]*\/.*\) ]]
+	then
+		echo "Thanks for using the admin PR template."
+		remove_clubhouse_labels
+		exit 0
   else
   	echo "yo dawg, where da clubhouse card at?"
 		add_clubhouse_label

--- a/check_for_clubhouse.sh
+++ b/check_for_clubhouse.sh
@@ -65,7 +65,7 @@ main() {
 		echo "Commit messages contain a clubhouse card. You may proceed...this time."
 		remove_clubhouse_labels
 		exit 0
-	elif [[ ${GITHUB_REF} =~ (\/ch[0-9](.+)\/*)([^,]*) ]]
+	elif [[ ${GITHUB_REF} =~ (\/ch[0-9](.+)\/*)([^,]*) ]] || [[ ${PR_HEAD} =~ (\/ch[0-9](.+)\/*)([^,]*) ]]
 	then
 		echo "This branch was clearly created using the clubhouse helper."
 		remove_clubhouse_labels


### PR DESCRIPTION
Verified on: https://github.com/shipt/qa-mobile-automation/pull/577/checks?check_run_id=230085117

The logs show that the github_ref no longer matches the expected path, but the .head.ref does. Using that instead.