### PR TITLE
chore: updates readme to reflect correct directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ workflow "Check branch/comment/body format" {
 }
 
 action "Clubhouse Checker" {
-  uses = "newshipt/clubhouse_check@master"
+  uses = "shipt/clubhouse_check@master"
   secrets = ["GITHUB_TOKEN"]
 }
 ```
 
 ### Expected formats:
-BRANCH REF:  */ch***/*
+
+BRANCH REF: \*/ch*\*\*/*
 
 COMMIT MESSAGE: [ch***]
 


### PR DESCRIPTION
Based on recent failing errors in our Github actions, I assume`newshipt/clubhouse_check@master` is no longer true and should be `shipt/clubhouse_check@master`. This PR simply updates the readme to reflect that change.